### PR TITLE
Setup icotool dependency check

### DIFF
--- a/install_rdesktop_fix
+++ b/install_rdesktop_fix
@@ -15,6 +15,9 @@ if [ $# -lt 1 ] || [[ $1 == *"help"* ]] || [[ $1 == *"?"* ]]; then
 	exit
 fi
 
+# Check Dependency
+command -v icotool >/dev/null 2>&1 || { echo >&2 "You are missing the dependency: 'icoutils'. Specifically the tool: 'icotool'.  Aborting."; exit 1; }
+
 # Create installation directory if needed
 if [ $# -gt 2 ]; then
 	INST_DIR=$1


### PR DESCRIPTION
I love your script!!! It fixed a big gripe I had with rdesktop. Thank you for this. I ran into the issue where I didn't have icotool installed and so your script failed on run. Once I did an 'apt-get install icoutils' your script ran great. So I decided to add a dependency check for it. 
